### PR TITLE
fix: remove watchdog config

### DIFF
--- a/jellyfin-server/config.yaml
+++ b/jellyfin-server/config.yaml
@@ -15,7 +15,6 @@ map:
   - media:rw
   - ssl
 video: true
-watchdog: http://[HOST]:[PORT:8096]/health
 ports:
   8096/tcp: 8096
   8920/tcp: null

--- a/jellyfin-server/config.yaml
+++ b/jellyfin-server/config.yaml
@@ -15,7 +15,7 @@ map:
   - media:rw
   - ssl
 video: true
-watchdog: http://[HOST]:8096/health
+watchdog: http://[HOST]:[PORT:8096]/health
 ports:
   8096/tcp: 8096
   8920/tcp: null


### PR DESCRIPTION
Jellyfin docker image now provides HEALTHCHECK directive on its own