### PR TITLE
feat: move log dir to /share/jellyfin/log

### DIFF
--- a/jellyfin-server/Dockerfile
+++ b/jellyfin-server/Dockerfile
@@ -5,6 +5,7 @@ FROM $BUILD_FROM
 ENV JELLYFIN_DATA_DIR=/share/jellyfin
 ENV JELLYFIN_CONFIG_DIR=/share/jellyfin/config
 ENV JELLYFIN_CACHE_DIR=/share/jellyfin/cache
+ENV JELLYFIN_LOG_DIR=/share/jellyfin/log
 
 # Override original entrypoint
 ENTRYPOINT ["./jellyfin/jellyfin"]


### PR DESCRIPTION
Set env var `JELLYFIN_LOG_DIR=/share/jellyfin/log`
Previous logdir was `/config/log`

Closes #34