### PR TITLE
fix: mount addon_config instead of config

### DIFF
--- a/jellyfin-server-hn/config.yaml
+++ b/jellyfin-server-hn/config.yaml
@@ -10,7 +10,7 @@ arch:
   - amd64
 init: false
 map:
-  - config:rw
+  - addon_config:rw
   - share:rw
   - media:rw
   - ssl

--- a/jellyfin-server/config.yaml
+++ b/jellyfin-server/config.yaml
@@ -10,7 +10,7 @@ arch:
   - amd64
 init: false
 map:
-  - config:rw
+  - addon_config:rw
   - share:rw
   - media:rw
   - ssl


### PR DESCRIPTION
It is not currently used, since all configs are redirected to share, but if in future would jellyfin use the directory on its own, lets use new safer location.

Should not affect current installations.