### PR TITLE
docs: update CHANGELOG.md for Jellyfin Server 10.11.8

### DIFF
--- a/jellyfin-server/CHANGELOG.md
+++ b/jellyfin-server/CHANGELOG.md
@@ -10,8 +10,24 @@
 
 ### Bug Fixes
 
-* **deps:** bump jellyfin/jellyfin in /jellyfin-server ([6a38b89](https://github.com/mdvorak/ha-addon-jellyfin/commit/6a38b89026f424f09be222ab7a78f6869584ab9c))
+* **deps:** bump jellyfin/jellyfin in /jellyfin-server to 10.11.8 ([6a38b89](https://github.com/mdvorak/ha-addon-jellyfin/commit/6a38b89026f424f09be222ab7a78f6869584ab9c))
 * push backward-compat arch-suffixed image aliases ([4a7a622](https://github.com/mdvorak/ha-addon-jellyfin/commit/4a7a622c118f409b32053bfa4b607376117ba66e))
+
+### [:rocket: Jellyfin Server 10.11.8](https://github.com/jellyfin/jellyfin/releases/tag/v10.11.8)
+
+We are pleased to announce the latest stable release of Jellyfin, version 10.11.8! This minor release brings several bugfixes to improve your Jellyfin experience. As always, please ensure you take a full backup before upgrading!
+
+**Note**: This release fixes several regressions from 10.11.7, with the goal to get people onto an updated release due to the forthcoming (t-minus 9 days) release of the GHSAs/CVEs that were fixed in 10.11.7. Please upgrade to this release as soon as you can.
+
+You can find more details about and discuss this release [on our forums](https://forum.jellyfin.org/t-new-jellyfin-server-web-release-10-11-8).
+
+#### Changelog (3)
+
+##### 📈 General Changes
+* Handle folders without associated library in FixLibrarySubtitleDownloadLanguages [PR #16540], by @Shadowghost
+* Fix subtitle saving [PR #16539], by @MBR-0001
+* Fix querying media with language filters [PR #16538], by @MBR-0001
+
 
 ## [2.0.8](https://github.com/mdvorak/ha-addon-jellyfin/compare/v2.0.7...v2.0.8) (2026-04-06)
 


### PR DESCRIPTION
Updated the changelog for Jellyfin Server to include version 10.11.8 release notes and bug fixes.