### PR TITLE
ci: strip #<num> issue/PR references from Jellyfin release notes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -85,6 +85,8 @@ jobs:
             body="$(sed 's/:rocket: //g' <<< "$body")"
             # Strip @ prefix from name references
             body="$(sed 's/@\([a-zA-Z0-9_-]*\)/\1/g' <<< "$body")"
+            # Strip # from issue/PR number references (avoids invalid cross-repo links)
+            body="$(sed 's/#\([0-9]\+\)/\1/g' <<< "$body")"
             # Linkify the first top-level heading (the release title) with the release URL
             shifted="$(sed "0,/^# /s|^# \(.*\)|# [\1](${url})|" <<< "$body")"
             # Demote all headings by two levels so they nest under our PR-level headings


### PR DESCRIPTION
## Summary

- Adds a `sed` pass to strip `#` from bare issue/PR number references (e.g. `#123` → `123`) in Jellyfin release notes appended to the release-please PR body
- Cross-repo `#<num>` references would otherwise resolve as invalid links pointing to issues in this repo
- Pattern `#\([0-9]\+\)` only matches `#` immediately followed by digits, so Markdown headings (`# Title`, `## Section`) are unaffected

## Test plan

- [ ] Trigger a release-please run after a Jellyfin version bump and verify the appended release notes contain plain numbers instead of `#123`-style references
- [ ] Confirm headings in the appended notes are still rendered correctly